### PR TITLE
NCSD-2424: App settings for search

### DIFF
--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -55,6 +55,15 @@
         },
         "ApimLoggerName": {
             "value": "__ApimLoggerName__"
+        },
+        "JobProfileSearchIndexName": {
+            "value": "__JpSearchIndexName__"
+        },
+        "JobProfileSearchServiceName": {
+            "value": "__JpSearchServiceName__"
+        },
+        "JobProfileSearchServiceAccessKey": {
+            "value": "__JpSearchServiceAccessKey__"
         }
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -65,6 +65,15 @@
         },
         "ApimLoggerName": {
             "type": "string"
+        },
+        "JobProfileSearchIndexName": {
+            "type": "string"
+        },
+        "JobProfileSearchServiceName": {
+            "type": "string"
+        },
+        "JobProfileSearchServiceAccessKey": {
+            "type": "securestring"
         }
     },
     "variables": {
@@ -244,6 +253,18 @@
                             {
                                 "name": "AzureWebJobsStorage",
                                 "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('appSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('appSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+                            },
+                            {
+                                "name": "JobProfileSearchIndexConfig__SearchIndex",
+                                "value": "[parameters('JobProfileSearchIndexName')]"
+                            },
+                            {
+                                "name": "JobProfileSearchIndexConfig__SearchServiceName",
+                                "value": "[parameters('JobProfileSearchServiceName')]"
+                            },
+                            {
+                                "name": "JobProfileSearchIndexConfig__AccessKey",
+                                "value": "[parameters('JobProfileSearchServiceAccessKey')]"
                             },
                             {
                                 "name": "Configuration__CosmosDbConnections__JobProfileSegment__AccessKey",

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -43,6 +43,15 @@
         },
         "ApimLoggerName": {
             "value": "some-apim-logger"
+        },
+        "JobProfileSearchIndexName": {
+            "value": "dfc-digital-jobprofiles-r999"
+        },
+        "JobProfileSearchServiceName": {
+            "value": "dfc-foo-search"
+        },
+        "JobProfileSearchServiceAccessKey": {
+            "value": "not-a-real-query-key"
         }
     }
 }


### PR DESCRIPTION
Added app settings for the new search API. This hits the same problem DYSAC had regarding getting the search index name. A longer term solution will be needed.