### PR TITLE
Merge Release 34.2 to master

### DIFF
--- a/DFC.Api.JobProfiles.Common/DFC.Api.JobProfiles.Common.csproj
+++ b/DFC.Api.JobProfiles.Common/DFC.Api.JobProfiles.Common.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{1B4D0AFE-2E98-4565-ADAC-9292E0ED5D30}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/DFC.Api.JobProfiles.Data/AzureSearch/Models/JobProfileIndex.cs
+++ b/DFC.Api.JobProfiles.Data/AzureSearch/Models/JobProfileIndex.cs
@@ -1,6 +1,6 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Attributes;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+﻿using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using DFC.Api.JobProfiles.Data.AzureSearch.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -12,112 +12,101 @@ namespace DFC.Api.JobProfiles.Data.AzureSearch.Models
         [Key]
         public string IdentityField { get; set; }
 
-        [IsFilterable, IsSortable, IsFacetable]
+        [SimpleField(IsFilterable= true, IsSortable = true, IsFacetable = true)]
         public string SocCode { get; set; }
 
-        [IsSearchable, IsFilterable, IsSortable, IsSuggestible]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(IsFilterable = true, IsSortable = true, AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
+        [IsSuggestible]
         [AddWeighting(7)]
         public string Title { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.Keyword)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.Keyword)]
         [AddWeighting(100)]
         public string TitleAsKeyword => Title.ToLowerInvariant();
 
-        [IsSearchable, IsFilterable, IsSuggestible]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(IsFilterable = true, AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
+        [IsSuggestible]
         [AddWeighting(6)]
         public IEnumerable<string> AlternativeTitle { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.Keyword)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.Keyword)]
         [AddWeighting(100)]
         public IEnumerable<string> AltTitleAsKeywords => AlternativeTitle?.Select(a => a.ToLowerInvariant());
 
-        [IsSearchable]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         [AddWeighting(5)]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
         public string Overview { get; set; }
 
-        [IsFilterable, IsSortable, IsFacetable]
+        [SimpleField(IsFilterable= true, IsSortable = true, IsFacetable = true)]
         public double SalaryStarter { get; set; }
 
-        [IsFilterable, IsSortable, IsFacetable]
+        [SimpleField(IsFilterable= true, IsSortable = true, IsFacetable = true)]
         public double SalaryExperienced { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings", Justification = "This is an application field of type string, last segment and is not a complete uri")]
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public string UrlName { get; set; }
 
-        [IsSearchable, IsFilterable]
+        [SearchableField(IsFilterable= true, AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         [AddWeighting(4)]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
         public IEnumerable<string> JobProfileCategories { get; set; }
 
-        [IsSearchable, IsFilterable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(IsFilterable= true, AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         [AddWeighting(3)]
         public IEnumerable<string> JobProfileSpecialism { get; set; }
 
-        [IsSearchable, IsFilterable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(IsFilterable= true, AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         [AddWeighting(3)]
         public IEnumerable<string> HiddenAlternativeTitle { get; set; }
 
         public IEnumerable<string> JobProfileCategoriesWithUrl { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> Interests { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> Enablers { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> EntryQualifications { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> TrainingRoutes { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> PreferredTaskTypes { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> JobAreas { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         public string CollegeRelevantSubjects { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         public string UniversityRelevantSubjects { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         public string ApprenticeshipRelevantSubjects { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         public string WYDDayToDayTasks { get; set; }
 
-        [IsSearchable]
-        [Analyzer(AnalyzerName.AsString.EnLucene)]
+        [SearchableField(AnalyzerName = LexicalAnalyzerName.Values.EnLucene)]
         public string CareerPathAndProgression { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> WorkingPattern { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> WorkingPatternDetails { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public IEnumerable<string> WorkingHoursDetails { get; set; }
 
-        [IsFilterable, IsSortable, IsFacetable]
+        [SimpleField(IsFilterable= true, IsSortable = true, IsFacetable = true)]
         public double MinimumHours { get; set; }
 
-        [IsFilterable, IsSortable, IsFacetable]
+        [SimpleField(IsFilterable= true, IsSortable = true, IsFacetable = true)]
         public double MaximumHours { get; set; }
     }
 }

--- a/DFC.Api.JobProfiles.Data/DFC.Api.JobProfiles.Data.csproj
+++ b/DFC.Api.JobProfiles.Data/DFC.Api.JobProfiles.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{1DB07AF9-DDCF-4FB6-93CC-AE034F416342}</ProjectGuid>
@@ -12,13 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.15" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.27" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.Api.JobProfiles.ProfileServices.UnitTests/DFC.Api.JobProfiles.ProfileServices.UnitTests.csproj
+++ b/DFC.Api.JobProfiles.ProfileServices.UnitTests/DFC.Api.JobProfiles.ProfileServices.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -12,25 +12,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DFC.Api.JobProfiles.ProfileServices/DFC.Api.JobProfiles.ProfileServices.csproj
+++ b/DFC.Api.JobProfiles.ProfileServices/DFC.Api.JobProfiles.ProfileServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{3EA0D731-3EAD-49B1-BFFF-456FFC2266BC}</ProjectGuid>
@@ -12,11 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DFC.Api.JobProfiles.Repository.CosmosDb/DFC.Api.JobProfiles.Repository.CosmosDb.csproj
+++ b/DFC.Api.JobProfiles.Repository.CosmosDb/DFC.Api.JobProfiles.Repository.CosmosDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{3B77CB44-0296-419F-AE8F-E3041E2141A0}</ProjectGuid>
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DFC.Api.JobProfiles.SearchServices.UnitTests/AzureSearch/AzSearchQueryConverterTests.cs
+++ b/DFC.Api.JobProfiles.SearchServices.UnitTests/AzureSearch/AzSearchQueryConverterTests.cs
@@ -1,7 +1,9 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Models;
+﻿using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using DFC.Api.JobProfiles.Data.AzureSearch.Models;
 using DFC.Api.JobProfiles.SearchServices.AzureSearch;
 using FakeItEasy;
-using Microsoft.Azure.Search.Models;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -56,14 +58,16 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests.AzureSearch
         public void ConvertToSearchResultRaisesArgumentNullExceptionForMissingSearchProperties()
         {
             // Arrange
-            var searchResults = A.Fake<IList<Microsoft.Azure.Search.Models.SearchResult<JobProfileIndex>>>();
-            var facets = A.Fake<IDictionary<string, IList<FacetResult>>>();
-            var result = new DocumentSearchResult<JobProfileIndex>(searchResults, 0, 0, facets, null);
+            var fakeResults = A.Fake<IEnumerable<Azure.Search.Documents.Models.SearchResult<JobProfileIndex>>>();
+            var fakeFacets = A.Fake<IDictionary<string, IList<FacetResult>>>();
+            var fakeResponse = A.Fake<Response>();
+            var modelledResults = SearchModelFactory.SearchResults<JobProfileIndex>(fakeResults, 0, fakeFacets, 0, fakeResponse); // maybe null response
+
             SearchProperties searchProperties = null;
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
             // Act
-            var exceptionResult = Assert.Throws<ArgumentNullException>(() => azSearchQueryConverter.ConvertToSearchResult(result, searchProperties));
+            var exceptionResult = Assert.Throws<ArgumentNullException>(() => azSearchQueryConverter.ConvertToSearchResult(modelledResults, searchProperties));
 
             // assert
             Assert.Equal("Value cannot be null. (Parameter 'properties')", exceptionResult.Message);
@@ -73,39 +77,40 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests.AzureSearch
         public void ConvertToSearchResultRaisesArgumentNullExceptionForMissingResult()
         {
             // Arrange
-            DocumentSearchResult<JobProfileIndex> result = null;
+            SearchResults<JobProfileIndex> results = null;
             var searchProperties = A.Fake<SearchProperties>();
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
             // Act
-            var exceptionResult = Assert.Throws<ArgumentNullException>(() => azSearchQueryConverter.ConvertToSearchResult(result, searchProperties));
+            var exceptionResult = Assert.Throws<ArgumentNullException>(() => azSearchQueryConverter.ConvertToSearchResult(results, searchProperties));
 
             // assert
-            Assert.Equal("Value cannot be null. (Parameter 'result')", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'results')", exceptionResult.Message);
         }
 
         [Fact]
         public void ConvertToSearchResultReturnsSearchResultForSearchProperties()
         {
             // Arrange
-            var searchResults = A.Fake<IList<Microsoft.Azure.Search.Models.SearchResult<JobProfileIndex>>>();
+            var fakeResults = A.Fake<IEnumerable<Azure.Search.Documents.Models.SearchResult<JobProfileIndex>>>();
             var facets = A.Fake<IDictionary<string, IList<FacetResult>>>();
-            var result = new DocumentSearchResult<JobProfileIndex>(searchResults, 0, 0, facets, null);
+            var fakeResponse = A.Fake<Response>();
+            var modelledResults = SearchModelFactory.SearchResults<JobProfileIndex>(fakeResults, 0, facets, 0, fakeResponse); // maybe null response
             var searchProperties = A.Fake<SearchProperties>();
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
             // Act
-            var results = azSearchQueryConverter.ConvertToSearchResult(result, searchProperties);
+            var finalResult = azSearchQueryConverter.ConvertToSearchResult(modelledResults, searchProperties);
 
             // Assert
-            Assert.NotNull(results);
+            Assert.NotNull(finalResult);
         }
 
         [Fact]
         public void ConvertToSuggestionResultRaisesArgumentNullExceptionForMissingSearchProperties()
         {
             // Arrange
-            var result = A.Fake<DocumentSuggestResult<JobProfileIndex>>();
+            var result = A.Fake<SuggestResults<JobProfileIndex>>();
             SuggestProperties suggestProperties = null;
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
@@ -120,7 +125,7 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests.AzureSearch
         public void ConvertToSuggestionResultRaisesArgumentNullExceptionForMissingResult()
         {
             // Arrange
-            DocumentSuggestResult<JobProfileIndex> result = null;
+            SuggestResults<JobProfileIndex> result = null;
             var suggestProperties = A.Fake<SuggestProperties>();
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
@@ -135,15 +140,15 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests.AzureSearch
         public void ConvertToSuggestionResultReturnsSuggestionResultForSearchProperties()
         {
             // Arrange
-            var result = A.Fake<DocumentSuggestResult<JobProfileIndex>>();
-            var suggestProperties = A.Fake<SuggestProperties>();
+            var fakeResult = A.Fake<SuggestResults<JobProfileIndex>>();
+            var fakeSuggestProperties = A.Fake<SuggestProperties>();
             var azSearchQueryConverter = new AzSearchQueryConverter();
 
             // Act
-            var results = azSearchQueryConverter.ConvertToSuggestionResult(result, suggestProperties);
+            var finalResult = azSearchQueryConverter.ConvertToSuggestionResult(fakeResult, fakeSuggestProperties);
 
             // Assert
-            Assert.NotNull(results);
+            Assert.NotNull(finalResult);
         }
     }
 }

--- a/DFC.Api.JobProfiles.SearchServices.UnitTests/DFC.Api.JobProfiles.SearchServices.UnitTests.csproj
+++ b/DFC.Api.JobProfiles.SearchServices.UnitTests/DFC.Api.JobProfiles.SearchServices.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -13,25 +13,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DFC.Api.JobProfiles.SearchServices.UnitTests/DfcSearchQueryServiceTests.cs
+++ b/DFC.Api.JobProfiles.SearchServices.UnitTests/DfcSearchQueryServiceTests.cs
@@ -1,12 +1,8 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Models;
+﻿using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using DFC.Api.JobProfiles.Data.AzureSearch.Models;
 using DFC.Api.JobProfiles.SearchServices.Interfaces;
-
 using FakeItEasy;
-
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
-
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,12 +21,11 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests
         public async Task SearchAsyncTest()
         {
             //Arrange
-            var fakeIndexClient = A.Fake<ISearchIndexClient>(o => o.Strict());
+            var fakeSearchClient = A.Fake<SearchClient>();
             var fakeQueryBuilder = A.Fake<ISearchQueryBuilder>(o => o.Strict());
             var fakeQueryConverter = A.Fake<IAzSearchQueryConverter>(o => o.Strict());
-            var fakeDocumentsOperation = A.Fake<IDocumentsOperations>();
             var dummySearchProperty = A.Dummy<SearchProperties>();
-            var dummySearchParameters = A.Dummy<SearchParameters>();
+            var dummySearchParameters = A.Dummy<SearchOptions>();
             var dummySearchResult = A.Dummy<Data.AzureSearch.Models.SearchResult<JobProfileIndex>>();
             var fakeManipulator = A.Fake<ISearchManipulator<JobProfileIndex>>();
 
@@ -39,12 +34,11 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests
             A.CallTo(() => fakeQueryBuilder.BuildContainPartialSearch(A<string>._, A<SearchProperties>._)).Returns(PartialTermToSearch);
             A.CallTo(() => fakeQueryBuilder.TrimCommonWordsAndSuffixes(A<string>._, A<SearchProperties>._)).Returns(TrimmedResults);
             A.CallTo(() => fakeQueryConverter.BuildSearchParameters(A<SearchProperties>._)).Returns(dummySearchParameters);
-            A.CallTo(() => fakeIndexClient.Documents).Returns(fakeDocumentsOperation);
-            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<DocumentSearchResult<JobProfileIndex>>._, A<SearchProperties>._)).Returns(dummySearchResult);
+            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<SearchResults<JobProfileIndex>>._, A<SearchProperties>._)).Returns(dummySearchResult);
             A.CallTo(() => fakeManipulator.BuildSearchExpression(A<string>._, A<string>._, A<string>._, A<SearchProperties>._)).Returns(nameof(fakeManipulator.BuildSearchExpression));
 
             //Act
-            var searchService = new DfcSearchQueryService<JobProfileIndex>(fakeQueryConverter, fakeQueryBuilder, fakeManipulator, fakeIndexClient);
+            var searchService = new DfcSearchQueryService<JobProfileIndex>(fakeQueryConverter, fakeQueryBuilder, fakeManipulator, fakeSearchClient);
             await searchService.SearchAsync("searchTerm", dummySearchProperty).ConfigureAwait(false);
 
             //Assert
@@ -52,9 +46,8 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests
             A.CallTo(() => fakeQueryBuilder.TrimCommonWordsAndSuffixes(A<string>.That.IsEqualTo(CleanedSearchTerm), A<SearchProperties>._)).MustHaveHappened();
             A.CallTo(() => fakeQueryBuilder.BuildContainPartialSearch(A<string>.That.IsEqualTo(TrimmedResults), A<SearchProperties>._)).MustHaveHappened();
             A.CallTo(() => fakeQueryConverter.BuildSearchParameters(A<SearchProperties>._)).MustHaveHappened();
-            A.CallTo(() => fakeIndexClient.Documents).MustHaveHappened();
-            A.CallTo(() => fakeDocumentsOperation.SearchWithHttpMessagesAsync<JobProfileIndex>(A<string>.That.IsEqualTo(nameof(fakeManipulator.BuildSearchExpression)), A<SearchParameters>._, A<SearchRequestOptions>._, A<Dictionary<string, List<string>>>._, A<CancellationToken>._)).MustHaveHappened();
-            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<DocumentSearchResult<JobProfileIndex>>._, A<SearchProperties>._)).MustHaveHappened();
+            A.CallTo(() => fakeSearchClient.SearchAsync<JobProfileIndex>(A<string>.That.IsEqualTo(nameof(fakeManipulator.BuildSearchExpression)), A<SearchOptions>._, A<CancellationToken>._)).MustHaveHappened();
+            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<SearchResults<JobProfileIndex>>._, A<SearchProperties>._)).MustHaveHappened();
         }
 
         [Theory]
@@ -69,27 +62,24 @@ namespace DFC.Api.JobProfiles.SearchServices.UnitTests
             var actualManipulator = new JobProfileSearchManipulator();
 
             //Fakes
-            var fakeIndexClient = A.Fake<ISearchIndexClient>(o => o.Strict());
+            var fakeSearchClient = A.Fake<SearchClient>();
             var fakeQueryConverter = A.Fake<IAzSearchQueryConverter>(o => o.Strict());
-            var fakeDocumentsOperation = A.Fake<IDocumentsOperations>();
             var dummySearchProperty = A.Dummy<SearchProperties>();
-            var dummySearchParameters = A.Dummy<SearchParameters>();
+            var dummySearchParameters = A.Dummy<SearchOptions>();
             var dummySearchResult = A.Dummy<Data.AzureSearch.Models.SearchResult<JobProfileIndex>>();
 
             //Configure
             A.CallTo(() => fakeQueryConverter.BuildSearchParameters(A<SearchProperties>._)).Returns(dummySearchParameters);
-            A.CallTo(() => fakeIndexClient.Documents).Returns(fakeDocumentsOperation);
-            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<DocumentSearchResult<JobProfileIndex>>._, A<SearchProperties>._)).Returns(dummySearchResult);
+            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<SearchResults<JobProfileIndex>>._, A<SearchProperties>._)).Returns(dummySearchResult);
 
             //Act
-            var searchService = new DfcSearchQueryService<JobProfileIndex>(fakeQueryConverter, actualQueryBuilder, actualManipulator, fakeIndexClient);
+            var searchService = new DfcSearchQueryService<JobProfileIndex>(fakeQueryConverter, actualQueryBuilder, actualManipulator, fakeSearchClient);
             await searchService.SearchAsync(searchTerm, dummySearchProperty).ConfigureAwait(false);
 
             //Assert
             A.CallTo(() => fakeQueryConverter.BuildSearchParameters(A<SearchProperties>._)).MustHaveHappened();
-            A.CallTo(() => fakeIndexClient.Documents).MustHaveHappened();
-            A.CallTo(() => fakeDocumentsOperation.SearchWithHttpMessagesAsync<JobProfileIndex>(A<string>.That.Contains(expectedComputedSearchTerm), A<SearchParameters>._, A<SearchRequestOptions>._, A<Dictionary<string, List<string>>>._, A<CancellationToken>._)).MustHaveHappened();
-            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<DocumentSearchResult<JobProfileIndex>>._, A<SearchProperties>._)).MustHaveHappened();
+            A.CallTo(() => fakeSearchClient.SearchAsync<JobProfileIndex>(A<string>.That.Contains(expectedComputedSearchTerm), A<SearchOptions>._, A<CancellationToken>._)).MustHaveHappened();
+            A.CallTo(() => fakeQueryConverter.ConvertToSearchResult(A<SearchResults<JobProfileIndex>>._, A<SearchProperties>._)).MustHaveHappened();
         }
     }
 }

--- a/DFC.Api.JobProfiles.SearchServices/DFC.Api.JobProfiles.SearchServices.csproj
+++ b/DFC.Api.JobProfiles.SearchServices/DFC.Api.JobProfiles.SearchServices.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <ProjectGuid>{9EB60458-D082-44AA-A452-B5E7F283B095}</ProjectGuid>
@@ -12,13 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.Api.JobProfiles.SearchServices/DfcSearchQueryService.cs
+++ b/DFC.Api.JobProfiles.SearchServices/DfcSearchQueryService.cs
@@ -1,9 +1,7 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Models;
+﻿using Azure.Search.Documents;
+using DFC.Api.JobProfiles.Data.AzureSearch.Models;
 using DFC.Api.JobProfiles.SearchServices.AzureSearch;
 using DFC.Api.JobProfiles.SearchServices.Interfaces;
-
-using Microsoft.Azure.Search;
-
 using System.Threading.Tasks;
 
 namespace DFC.Api.JobProfiles.SearchServices
@@ -18,8 +16,8 @@ namespace DFC.Api.JobProfiles.SearchServices
             IAzSearchQueryConverter queryConverter,
             ISearchQueryBuilder queryBuilder,
             ISearchManipulator<T> searchManipulator,
-            ISearchIndexClient searchIndexClient)
-            : base(queryConverter, searchIndexClient)
+            SearchClient searchClient)
+            : base(queryConverter, searchClient)
         {
             this.queryBuilder = queryBuilder;
             this.searchManipulator = searchManipulator;

--- a/DFC.Api.JobProfiles.SearchServices/Extensions/SearchExtensions.cs
+++ b/DFC.Api.JobProfiles.SearchServices/Extensions/SearchExtensions.cs
@@ -1,5 +1,5 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Models;
-using Microsoft.Azure.Search.Models;
+﻿using Azure.Search.Documents.Models;
+using DFC.Api.JobProfiles.Data.AzureSearch.Models;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -9,24 +9,25 @@ namespace DFC.Api.JobProfiles.SearchServices.Extensions
     [ExcludeFromCodeCoverage]
     public static class SearchExtensions
     {
-        public static IEnumerable<SearchResultItem<T>> ToSearchResultItems<T>(this DocumentSearchResult<T> results, SearchProperties properties)
-            where T : class
+        public static IEnumerable<SearchResultItem<T>> ToSearchResultItems<T>(this SearchResults<T> results, SearchProperties properties)
+        where T : class
         {
             if (properties != null && results != null)
             {
                 var beginRank = ((properties.Page - 1) * properties.Count) + properties.ExactMatchCount;
 
                 var resultList = new List<SearchResultItem<T>>();
-                if (results.Results != null)
+
+                if (results.GetResults() != null)
                 {
-                    foreach (var result in results.Results)
+                    foreach (var result in results.GetResults())
                     {
                         beginRank++;
                         resultList.Add(new SearchResultItem<T>
                         {
                             ResultItem = result.Document,
                             Rank = beginRank,
-                            Score = result.Score,
+                            Score = (double)result.Score,
                         });
                     }
                 }
@@ -37,7 +38,7 @@ namespace DFC.Api.JobProfiles.SearchServices.Extensions
             return Enumerable.Empty<SearchResultItem<T>>();
         }
 
-        public static IEnumerable<SuggestionResultItem<T>> ToSuggestResultItems<T>(this DocumentSuggestResult<T> results)
+        public static IEnumerable<SuggestionResultItem<T>> ToSuggestResultItems<T>(this SuggestResults<T> results)
             where T : class
         {
             return results?.Results?.Select(r => new SuggestionResultItem<T>

--- a/DFC.Api.JobProfiles.SearchServices/Interfaces/IAzSearchQueryConverter.cs
+++ b/DFC.Api.JobProfiles.SearchServices/Interfaces/IAzSearchQueryConverter.cs
@@ -1,18 +1,19 @@
-﻿using DFC.Api.JobProfiles.Data.AzureSearch.Models;
-using Microsoft.Azure.Search.Models;
+﻿using Azure.Search.Documents;
+using Azure.Search.Documents.Models;
+using DFC.Api.JobProfiles.Data.AzureSearch.Models;
 
 namespace DFC.Api.JobProfiles.SearchServices.Interfaces
 {
     public interface IAzSearchQueryConverter
     {
-        SearchParameters BuildSearchParameters(SearchProperties properties);
+        SearchOptions BuildSearchParameters(SearchProperties properties);
 
-        Data.AzureSearch.Models.SearchResult<T> ConvertToSearchResult<T>(DocumentSearchResult<T> result, SearchProperties properties)
+        Data.AzureSearch.Models.SearchResult<T> ConvertToSearchResult<T>(Azure.Search.Documents.Models.SearchResults<T> result, SearchProperties properties)
             where T : class;
 
-        SuggestParameters BuildSuggestParameters(SuggestProperties properties);
+        SuggestOptions BuildSuggestParameters(SuggestProperties properties);
 
-        Data.AzureSearch.Models.SuggestionResult<T> ConvertToSuggestionResult<T>(DocumentSuggestResult<T> result, SuggestProperties properties)
+        SuggestionResult<T> ConvertToSuggestionResult<T>(SuggestResults<T> result, SuggestProperties properties)
             where T : class;
     }
 }

--- a/DFC.Api.JobProfiles.UnitTests/DFC.Api.JobProfiles.UnitTests.csproj
+++ b/DFC.Api.JobProfiles.UnitTests/DFC.Api.JobProfiles.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -12,22 +12,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DFC.Api.JobProfiles/DFC.Api.JobProfiles.csproj
+++ b/DFC.Api.JobProfiles/DFC.Api.JobProfiles.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
 	<ProjectGuid>{ADC6F28A-3F83-4EEB-A48E-A119691F911F}</ProjectGuid>
@@ -13,23 +13,20 @@
 
   <ItemGroup>
     <PackageReference Include="AzureFunctions.Extensions.Swashbuckle" Version="1.4.5-preview5" />
-    <PackageReference Include="Dfc.SharedConfig" Version="0.1.5" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
+    <PackageReference Include="Dfc.SharedConfig" Version="0.1.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="DFC.Functions.DI.Standard" Version="0.1.0" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.15" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.27" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DFC.Api.JobProfiles.Common\DFC.Api.JobProfiles.Common.csproj" />

--- a/DFC.Api.JobProfiles/WebJobsExtensionStartup.cs
+++ b/DFC.Api.JobProfiles/WebJobsExtensionStartup.cs
@@ -1,7 +1,6 @@
-﻿using AutoMapper;
-
+﻿using Azure;
+using Azure.Search.Documents;
 using AzureFunctions.Extensions.Swashbuckle;
-
 using DFC.Api.JobProfiles;
 using DFC.Api.JobProfiles.Common.Services;
 using DFC.Api.JobProfiles.Data.AzureSearch.Models;
@@ -13,16 +12,13 @@ using DFC.Api.JobProfiles.SearchServices.AzureSearch;
 using DFC.Api.JobProfiles.SearchServices.Interfaces;
 using DFC.Functions.DI.Standard;
 using DFC.Swagger.Standard;
-
-using Microsoft.Azure.Documents;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Search;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -47,15 +43,29 @@ namespace DFC.Api.JobProfiles
 
             var cosmosDbConnection = configuration.GetSection(CosmosDbConfigAppSettings).Get<CosmosDbConnection>();
             var searchIndexSettings = configuration.GetSection(AzureSearchConfigAppSettings).Get<SearchIndexSettings>() ?? throw new ArgumentException("SearchIndexSettings are invalid.");
-            var retryOptions = new RetryOptions { MaxRetryAttemptsOnThrottledRequests = 20, MaxRetryWaitTimeInSeconds = 60 };
+            var cosmosClientOptions = new CosmosClientOptions { MaxRetryAttemptsOnRateLimitedRequests = 20, MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(60) };
+            var searchServiceName = searchIndexSettings.SearchServiceName;
+
+            UriBuilder uriBuilder = new ()
+            {
+                Scheme = "https",
+                Host = $"{searchServiceName}.search.windows.net",
+            };
+            Uri searchServiceUri = uriBuilder.Uri;
 
             builder.AddDependencyInjection();
             builder.AddSwashBuckle(Assembly.GetExecutingAssembly());
             builder?.Services.AddApplicationInsightsTelemetry();
             builder?.Services.AddAutoMapper(typeof(WebJobsExtensionStartup).Assembly);
             builder?.Services.AddSingleton(cosmosDbConnection);
-            builder?.Services.AddSingleton<ISearchIndexClient>(new SearchIndexClient(searchIndexSettings.SearchServiceName, searchIndexSettings.SearchIndex, new SearchCredentials(searchIndexSettings.AccessKey)));
-            builder?.Services.AddSingleton<IDocumentClient>(new DocumentClient(new Uri(cosmosDbConnection.EndpointUrl), cosmosDbConnection.AccessKey, new ConnectionPolicy { RetryOptions = retryOptions }));
+            builder?.Services.AddSingleton<SearchClient>(new SearchClient(
+                endpoint: searchServiceUri,
+                searchIndexSettings.SearchIndex,
+                new AzureKeyCredential(searchIndexSettings.AccessKey)));
+            builder?.Services.AddSingleton<CosmosClient>(new CosmosClient(
+                cosmosDbConnection.EndpointUrl,
+                cosmosDbConnection.AccessKey,
+                cosmosClientOptions));
             builder?.Services.AddSingleton<IAzSearchQueryConverter, AzSearchQueryConverter>();
             builder?.Services.AddSingleton<ISearchQueryService<JobProfileIndex>, DfcSearchQueryService<JobProfileIndex>>();
             builder?.Services.AddSingleton<ISearchManipulator<JobProfileIndex>, JobProfileSearchManipulator>();

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -231,7 +231,7 @@
                         "value": [
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
-                                "value": "~3"
+                                "value": "~4"
                             },
                             {
                                 "name": "FUNCTIONS_WORKER_RUNTIME",

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -53,6 +53,5 @@ stages:
             SolutionBaseName: $(SolutionBaseName)
             BuildPlatform: $(BuildPlatform)
             BuildConfiguration: $(BuildConfiguration)
-            DotNetCoreVersion: 3.1.101 
             PublishWebApp: true
             TestSuffix: UnitTests


### PR DESCRIPTION
* upgraded nuget packages for compatibility for .NET6

* updated job profile index

* updated searchextensions for dfcsearch and azsearch

* azure search queries and tests updated for .NET6

* updated azure searchservicename uri

* dfc search queries and tests upgrade WIP

currently searchasync tests are failing

* updated cosmosrespository to .NET6

* added fields to searchparameterbuilder

added searchproperties orderbyfields and searchfields

* fixed dfcsearchquery tests

indexclient and documentsoperation uses searchclient now - removed duplicates

* updated Microsoft.Azure.Cosmos to latest version

* removed unused Microsoft.Azure.ServiceBus reference

* downgraded Microsoft.Spatial version for compatibility

matched Microsoft.Spatial version with Microsoft.Data.OData version

* updated to latest version of build tools

* downgraded nuget package versions for .NET6 compatability

* updated webjobs startup for Microsoft.Azure.Cosmos

Microsoft.Azure.Documents deprecated

---------